### PR TITLE
Add minimal PvZ clone

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,4 @@
-PvZ test
+# PvZ Clone
+
+This repository contains a very small HTML/JS/CSS implementation inspired by Plants vs. Zombies.
+Open `index.html` in a browser to play.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PvZ Clone</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>PvZ Clone</h1>
+    <div id="controls">
+        <button id="select-sunflower">Sunflower</button>
+        <button id="select-peashooter">Peashooter</button>
+        <span id="sun-count">Sun: 50</span>
+    </div>
+    <canvas id="game" width="900" height="500"></canvas>
+    <p id="status"></p>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,169 @@
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+const statusEl = document.getElementById('status');
+
+const ROWS = 5;
+const COLS = 9;
+const CELL_WIDTH = canvas.width / COLS;
+const CELL_HEIGHT = canvas.height / ROWS;
+
+const plants = [];
+const peas = [];
+const zombies = [];
+let lastZombieSpawn = 0;
+let gameOver = false;
+let selectedPlant = 'peashooter';
+let sun = 50;
+
+const sunflowerBtn = document.getElementById('select-sunflower');
+const peashooterBtn = document.getElementById('select-peashooter');
+const sunCountEl = document.getElementById('sun-count');
+
+sunflowerBtn.addEventListener('click', () => {
+    selectedPlant = 'sunflower';
+});
+
+peashooterBtn.addEventListener('click', () => {
+    selectedPlant = 'peashooter';
+});
+
+function updateSunDisplay() {
+    sunCountEl.textContent = `Sun: ${sun}`;
+}
+
+updateSunDisplay();
+
+canvas.addEventListener('click', (e) => {
+    if (gameOver) return;
+    const rect = canvas.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const col = Math.floor(x / CELL_WIDTH);
+    const row = Math.floor(y / CELL_HEIGHT);
+    if (!plants.some(p => p.row === row && p.col === col)) {
+        const cost = selectedPlant === 'sunflower' ? 50 : 100;
+        if (sun >= cost) {
+            plants.push({ type: selectedPlant, row, col, cooldown: 0, health: 5, sunTimer: 0 });
+            sun -= cost;
+            updateSunDisplay();
+        }
+    }
+});
+
+function spawnZombie() {
+    const row = Math.floor(Math.random() * ROWS);
+    zombies.push({ x: canvas.width, row, health: 5, speed: 40 });
+}
+
+function update(delta) {
+    // plants shoot peas
+    plants.forEach(p => {
+        if (p.type === 'peashooter') {
+            p.cooldown -= delta;
+            if (p.cooldown <= 0) {
+                peas.push({ x: p.col * CELL_WIDTH + CELL_WIDTH / 2, row: p.row });
+                p.cooldown = 1000; // shoot every second
+            }
+        } else if (p.type === 'sunflower') {
+            p.sunTimer += delta;
+            if (p.sunTimer >= 5000) {
+                sun += 25;
+                updateSunDisplay();
+                p.sunTimer = 0;
+            }
+        }
+    });
+
+    // update peas
+    for (let i = peas.length - 1; i >= 0; i--) {
+        const pea = peas[i];
+        pea.x += 0.4 * delta;
+        if (pea.x > canvas.width) {
+            peas.splice(i, 1);
+            continue;
+        }
+        zombies.forEach(z => {
+            if (z.row === pea.row && Math.abs(z.x - pea.x) < 10) {
+                z.health -= 1;
+                peas.splice(i, 1);
+            }
+        });
+    }
+
+    // update zombies
+    for (let i = zombies.length - 1; i >= 0; i--) {
+        const z = zombies[i];
+        z.x -= z.speed * (delta / 1000);
+        if (z.x < 0) {
+            gameOver = true;
+            statusEl.textContent = 'Game Over!';
+        }
+        const plant = plants.find(p => p.row === z.row && z.x < (p.col + 1) * CELL_WIDTH - 10);
+        if (plant) {
+            plant.health -= 0.02 * delta;
+            if (plant.health <= 0) {
+                plants.splice(plants.indexOf(plant), 1);
+            }
+        }
+        if (z.health <= 0) {
+            zombies.splice(i, 1);
+        }
+    }
+
+    // spawn zombies
+    lastZombieSpawn += delta;
+    if (lastZombieSpawn > 2000) {
+        spawnZombie();
+        lastZombieSpawn = 0;
+    }
+}
+
+function drawGrid() {
+    ctx.strokeStyle = '#333';
+    for (let i = 1; i < COLS; i++) {
+        ctx.beginPath();
+        ctx.moveTo(i * CELL_WIDTH, 0);
+        ctx.lineTo(i * CELL_WIDTH, canvas.height);
+        ctx.stroke();
+    }
+    for (let i = 1; i < ROWS; i++) {
+        ctx.beginPath();
+        ctx.moveTo(0, i * CELL_HEIGHT);
+        ctx.lineTo(canvas.width, i * CELL_HEIGHT);
+        ctx.stroke();
+    }
+}
+
+function draw() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    drawGrid();
+    // draw plants
+    plants.forEach(p => {
+        ctx.fillStyle = p.type === 'sunflower' ? 'orange' : 'green';
+        ctx.fillRect(p.col * CELL_WIDTH + 5, p.row * CELL_HEIGHT + 5, CELL_WIDTH - 10, CELL_HEIGHT - 10);
+    });
+    // draw peas
+    ctx.fillStyle = 'yellow';
+    peas.forEach(pea => {
+        ctx.beginPath();
+        ctx.arc(pea.x, pea.row * CELL_HEIGHT + CELL_HEIGHT / 2, 5, 0, Math.PI * 2);
+        ctx.fill();
+    });
+    // draw zombies
+    ctx.fillStyle = 'gray';
+    zombies.forEach(z => {
+        ctx.fillRect(z.x - CELL_WIDTH / 2, z.row * CELL_HEIGHT + 5, CELL_WIDTH - 10, CELL_HEIGHT - 10);
+    });
+}
+
+let lastTime = performance.now();
+function gameLoop(time) {
+    const delta = time - lastTime;
+    lastTime = time;
+    if (!gameOver) {
+        update(delta);
+        draw();
+        requestAnimationFrame(gameLoop);
+    }
+}
+requestAnimationFrame(gameLoop);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,18 @@
+body {
+    font-family: Arial, sans-serif;
+    text-align: center;
+    background-color: #f0f8ff;
+}
+
+#game {
+    border: 1px solid #333;
+    background-color: #90ee90;
+}
+
+#controls {
+    margin-bottom: 10px;
+}
+
+#controls button {
+    margin-right: 5px;
+}


### PR DESCRIPTION
## Summary
- implement a small Plants vs Zombies clone using HTML5 canvas
- add plant selection between sunflowers and peashooters
- display available sun and deduct costs when planting
- slow zombie movement to interpret speed per second

## Testing
- `npm test` *(fails: could not find package.json)*