### PR TITLE
Implement level progression and smarter shooting

### DIFF
--- a/README
+++ b/README
@@ -8,4 +8,6 @@ This repository contains a small HTML/JS/CSS implementation inspired by Plants v
 2. Open `index.html` in any modern browser.
 3. Click inside the grid to place plants and stop the zombies.
 
-The game now features a score counter, increasing difficulty and a restart button when you lose. Zombies spawn more slowly at first and speed up as the game progresses.
+The game now features a score counter, level progression and a restart button when you lose. Zombies spawn more slowly at first and speed up as the game progresses. Each level ends after a fixed number of zombies are defeated and the next level begins automatically.
+
+Peashooters will only fire when a zombie is in the same row, saving resources when lanes are empty.

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
         <button id="peashooterBtn">Peashooter (100)</button>
         <span>Sun: <span id="sun">50</span></span>
         <span>Score: <span id="score">0</span></span>
+        <span>Level: <span id="level">1</span></span>
         <span>Selected: <span id="selected">Peashooter</span></span>
         <button id="restart">Restart</button>
     </div>


### PR DESCRIPTION
## Summary
- add level indicator to UI
- peashooters now fire only when a zombie is in the same row
- introduce `startLevel` and progression logic so each level ends
- document new gameplay features

## Testing
- `node --version`
- `npm test` *(fails: Could not find package.json)*